### PR TITLE
Add Streamlit app for shareable portfolio

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,28 @@
 # Kam-GPT
-An AI-powered portfolio that represents **Kamran Shirazi** for recruiters and engineers.
 
-## Quick Start
+An AI-powered portfolio that represents **Kamran Shirazi** for recruiters and
+engineers. The core logic lives in `kam_gpt.generator` and powers a simple
+Streamlit application you can share publicly.
+
+## Quick start
+
 ```bash
-python -m venv .venv && source .venv/bin/activate
+python -m venv .venv
+source .venv/bin/activate
 pip install -r requirements.txt
 streamlit run app/app.py
+```
 
-```zsh
-cat > README.md << 'EOF'
-# Kam-GPT
-An AI-powered portfolio that represents **Kamran Shirazi** for recruiters and engineers.
+Open the printed URL in your browser to ask portfolio questions.
 
-## Quick Start
-python -m venv .venv && source .venv/bin/activate
-pip install -r requirements.txt
-streamlit run app/app.py
+## Shareable deployment
+
+1. Push this repository to GitHub.
+2. Sign in to [Streamlit Community Cloud](https://share.streamlit.io/) and select
+   **New app**.
+3. Point Streamlit to your GitHub repository and choose `app/app.py` as the app
+   entry point.
+4. Click **Deploy** to publish a URL you can share on LinkedIn or elsewhere.
+
+Streamlit will automatically install the dependencies listed in
+`requirements.txt` and keep the app updated every time you push changes.

--- a/app/app.py
+++ b/app/app.py
@@ -1,0 +1,51 @@
+"""Streamlit interface for the Kam-GPT experience generator."""
+
+from __future__ import annotations
+
+import sys
+import textwrap
+from pathlib import Path
+
+import streamlit as st
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from kam_gpt import generate_engineer_response
+
+st.set_page_config(page_title="Kam-GPT", page_icon="🤖")
+
+st.title("Kam-GPT")
+st.caption("An interactive portfolio for Kamran Shirazi")
+
+with st.expander("How it works", expanded=False):
+    st.markdown(
+        textwrap.dedent(
+            """
+            Ask any question about Kamran's work and this app will surface the
+            most relevant experience snippet along with suggested follow-up
+            prompts. The underlying logic is lightweight and deterministic, so
+            it's easy to deploy anywhere Streamlit runs.
+            """
+        ).strip()
+    )
+
+prompt = st.text_area(
+    "What would you like to know?",
+    placeholder="Tell me about Android reliability work",
+    help="Questions are matched to curated experience stories using keyword "
+    "signals.",
+)
+
+if prompt:
+    response = generate_engineer_response(prompt)
+    st.subheader("Answer")
+    st.write(response["answer"])
+
+    follow_ups = response.get("follow_up_questions")
+    if follow_ups:
+        st.subheader("Follow-up questions")
+        st.markdown("\n".join(f"- {question}" for question in follow_ups))
+else:
+    st.info("Enter a question to explore Kamran's experience portfolio.")

--- a/kam_gpt/__init__.py
+++ b/kam_gpt/__init__.py
@@ -1,0 +1,5 @@
+"""Utilities for generating responses for Kam-GPT."""
+
+from .generator import generate_engineer_response
+
+__all__ = ["generate_engineer_response"]

--- a/kam_gpt/generator.py
+++ b/kam_gpt/generator.py
@@ -1,0 +1,167 @@
+"""Logic for choosing the best experience-based response.
+
+This module contains the keyword definitions for each experience that Kamran
+likes to highlight as well as the helper utilities that score incoming
+questions.  The selection logic is intentionally simple so it can run inside
+Streamlit without depending on an LLM.
+"""
+from __future__ import annotations
+
+import dataclasses
+import re
+from typing import List, Sequence
+
+_WORD_RE = re.compile(r"\b\w+\b")
+
+
+@dataclasses.dataclass(frozen=True)
+class Experience:
+    """Representation of a portfolio story that can be surfaced to a user."""
+
+    name: str
+    keywords: Sequence[str]
+    answer: str
+    follow_up_questions: Sequence[str]
+
+
+def _tokenize(text: str) -> List[str]:
+    """Tokenize *text* into lowercase word tokens.
+
+    The helper makes the behaviour explicit and testable instead of relying on
+    Python's ``split`` which struggles with punctuation.  ``_select_experience``
+    and ``generate_engineer_response`` both depend on the function so questions
+    are scored with whole-word matching.
+    """
+
+    return [token.lower() for token in _WORD_RE.findall(text)]
+
+
+def _phrase_in_tokens(tokens: Sequence[str], phrase: str) -> bool:
+    """Return ``True`` when *phrase* (a word or multi-word phrase) is present.
+
+    Multi-word phrases are matched by requiring contiguous tokens, making it
+    possible to distinguish phrases like ``"return on investment"`` from the
+    word ``"return"`` on its own.
+    """
+
+    phrase_tokens = _tokenize(phrase)
+    if not phrase_tokens:
+        return False
+
+    if len(phrase_tokens) == 1:
+        return phrase_tokens[0] in tokens
+
+    window = len(phrase_tokens)
+    for index in range(len(tokens) - window + 1):
+        if list(tokens[index : index + window]) == phrase_tokens:
+            return True
+    return False
+
+
+EXPERIENCES: Sequence[Experience] = (
+    Experience(
+        name="data_quality",
+        keywords=(
+            "data quality",
+            "reliability",
+            "android",
+            "experiments",
+            "slo",
+            "metrics",
+            "crash",
+        ),
+        answer=(
+            "On the Android data-quality team I rebuilt the reliability pipeline so "
+            "that experimentation data could be trusted. We introduced better "
+            "validation, created SLO dashboards, and reduced crash loops by 37% "
+            "without blocking feature velocity."
+        ),
+        follow_up_questions=(
+            "How did you measure the impact on reliability?",
+            "What tooling supported the data-quality checks?",
+        ),
+    ),
+    Experience(
+        name="roi_story",
+        keywords=(
+            "roi",
+            "return",
+            "investment",
+            "executive",
+            "business",
+            "sales",
+        ),
+        answer=(
+            "I led a go-to-market analytics project that connected product usage "
+            "to revenue outcomes. By pairing cohort data with sales motion we "
+            "outlined a clear ROI narrative for executives deciding between "
+            "competing investments."
+        ),
+        follow_up_questions=(
+            "Which metrics resonated most with leadership?",
+            "How did the work influence roadmap priorities?",
+        ),
+    ),
+    Experience(
+        name="ml_infra",
+        keywords=("machine", "learning", "pipeline", "ml", "inference"),
+        answer=(
+            "I also operated a machine learning pipeline that supported near-real "
+            "time inference. That included tightening feedback loops between data "
+            "labelling, training, and deployment so product engineers could ship "
+            "personalised features confidently."
+        ),
+        follow_up_questions=(
+            "What guardrails kept the models stable?",
+            "How did you collaborate with product teams?",
+        ),
+    ),
+)
+
+DEFAULT_EXPERIENCE = EXPERIENCES[0]
+
+
+def _select_experience(question: str) -> Experience:
+    """Return the best matching :class:`Experience` for *question*.
+
+    The scoring logic uses token comparisons rather than raw substring checks to
+    prevent words like ``"roi"`` from being accidentally matched inside
+    ``"android"``.  The experience with the highest keyword hit count is chosen;
+    when no keywords match we fall back to :data:`DEFAULT_EXPERIENCE`.
+    """
+
+    tokens = _tokenize(question)
+    best = DEFAULT_EXPERIENCE
+    best_score = 0
+
+    for experience in EXPERIENCES:
+        score = sum(1 for keyword in experience.keywords if _phrase_in_tokens(tokens, keyword))
+        if score > best_score:
+            best = experience
+            best_score = score
+
+    return best
+
+
+def generate_engineer_response(question: str) -> dict:
+    """Generate the structured response for a portfolio question.
+
+    The function exposes the matched experience name so downstream components can
+    tailor styling or analytics without having to re-run the selection logic.
+    """
+
+    experience = _select_experience(question)
+    return {
+        "experience": experience.name,
+        "answer": experience.answer,
+        "follow_up_questions": list(experience.follow_up_questions),
+    }
+
+
+__all__ = [
+    "Experience",
+    "EXPERIENCES",
+    "DEFAULT_EXPERIENCE",
+    "_select_experience",
+    "generate_engineer_response",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+streamlit>=1.28

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import pathlib
+import sys
+
+# Ensure the project root is importable when tests are run from an isolated context.
+PROJECT_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1,0 +1,65 @@
+import pytest
+
+from kam_gpt.generator import (
+    DEFAULT_EXPERIENCE,
+    _phrase_in_tokens,
+    _select_experience,
+    _tokenize,
+    generate_engineer_response,
+)
+
+
+def test_android_reliability_selects_data_quality():
+    question = "Tell me about Android reliability work"
+    response = generate_engineer_response(question)
+
+    assert response["experience"] == "data_quality"
+
+
+def test_roi_question_selects_roi_story():
+    question = "What's the ROI on your last project?"
+    response = generate_engineer_response(question)
+
+    assert response["experience"] == "roi_story"
+
+
+def test_multiword_phrase_matching():
+    question = "Walk me through the return on investment study"
+    response = generate_engineer_response(question)
+
+    assert response["experience"] == "roi_story"
+
+    # Ensure that looking for "return on investment" does not spill into
+    # unrelated words like "android".
+    response = generate_engineer_response("Android reliability was the focus")
+    assert response["experience"] == "data_quality"
+
+
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        ("ROI?", ["roi"]),
+        ("Android reliability", ["android", "reliability"]),
+        ("Return-on-investment", ["return", "on", "investment"]),
+    ],
+)
+def test_tokenize_handles_punctuation(text, expected):
+    assert _tokenize(text) == expected
+
+
+@pytest.mark.parametrize(
+    "tokens, phrase, expected",
+    [
+        (["android", "reliability"], "android", True),
+        (["return", "on", "investment"], "return on investment", True),
+        (["return", "reliability", "investment"], "return on investment", False),
+    ],
+)
+def test_phrase_in_tokens(tokens, phrase, expected):
+    assert _phrase_in_tokens(tokens, phrase) is expected
+
+
+def test_select_experience_defaults_when_no_keywords_match():
+    experience = _select_experience("Tell me about hobbies outside work")
+
+    assert experience is DEFAULT_EXPERIENCE


### PR DESCRIPTION
## Summary
- add a Streamlit UI that lets visitors query the experience generator and view follow-up prompts
- document local setup plus Streamlit Community Cloud deployment steps for sharing a public URL
- declare the Streamlit dependency so hosted environments install the required package

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68df4c44662c83238c86d881aa32c185