### PR TITLE
Integrate GPT-4.1 responses into Kam-GPT

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ The Streamlit application exposes a chat interface so visitors can ask Kam-GPT a
 ```bash
 python -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt
+export OPENAI_API_KEY="sk-..."  # Optional, enables GPT-4.1 responses
 streamlit run app/app.py
 ```
 
@@ -25,5 +26,8 @@ streamlit run app/app.py
 
 ## Development Notes
 
-- The chat experience is backed by a small rule-based knowledge base in `app/app.py`.
-- Update the knowledge entries in `app/app.py` to reflect the latest achievements or contact details.
+- Provide an `OPENAI_API_KEY` environment variable to let Kam-GPT answer with OpenAI's
+  GPT-4.1 model. Without the key the app falls back to the built-in rule-based
+  knowledge base in `app/app.py`.
+- Update the knowledge entries in `app/app.py` to reflect the latest achievements or
+  contact details when relying on the built-in experience.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+openai>=1.35.10
 streamlit>=1.31


### PR DESCRIPTION
## Summary
- add GPT-4.1-powered chat responses with graceful fallback to the existing rule-based engine
- document the optional OPENAI_API_KEY environment variable and GPT model usage
- add the OpenAI SDK dependency required for live LLM responses

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68df9702ffb0832396fd945c5d8e75fc