### PR TITLE
Add grounded Streamlit RAG scaffolding

### DIFF
--- a/app/grounded_app.py
+++ b/app/grounded_app.py
@@ -1,0 +1,25 @@
+import streamlit as st
+from app.retrieval import search
+from pathlib import Path
+
+st.set_page_config(page_title="Kam-GPT (Grounded)")
+st.title("Kam-GPT (Grounded)")
+st.write("Answers grounded strictly in /data (resume, LinkedIn, portfolio).")
+
+policy = ""
+if Path("prompts/answer_policy.md").exists():
+    policy = Path("prompts/answer_policy.md").read_text()
+
+q = st.text_input("Ask about your background:")
+if st.button("Search") and q.strip():
+    hits = search(q, k=5, index_dir="index")
+    if not hits:
+        st.warning("I don’t find that in my portfolio data. Add details to /data and rebuild index.")
+    else:
+        st.subheader("Answer (grounded)")
+        st.write(hits[0]["text"][:800])
+        st.subheader("Evidence")
+        for h in hits: st.write(f"- {h['path']}")
+        if policy:
+            with st.expander("Answer Policy"):
+                st.code(policy)

--- a/app/retrieval.py
+++ b/app/retrieval.py
@@ -1,0 +1,21 @@
+import json, re
+from pathlib import Path
+import numpy as np, faiss
+
+def _embed_query(q, dim):
+    x = np.zeros((dim,), dtype="float32")
+    for tok in re.findall(r"[a-zA-Z0-9_]+", q.lower()):
+        x[hash(tok) % dim] += 1.0
+    x /= (np.linalg.norm(x)+1e-9)
+    return x.reshape(1, -1)
+
+def search(q, k=5, index_dir="index"):
+    idx = faiss.read_index(f"{index_dir}/faiss.index")
+    meta = json.loads(Path(f"{index_dir}/meta.json").read_text())
+    qv = _embed_query(q, idx.d)
+    sims, I = idx.search(qv, k)
+    results=[]
+    for rank,i in enumerate(I[0]):
+        if i<0: continue
+        results.append({"rank":rank+1,"score":float(sims[0][rank]),**meta[i]})
+    return results

--- a/data/github_portfolio.md
+++ b/data/github_portfolio.md
@@ -1,0 +1,6 @@
+---
+source: github
+updated: 2025-10-03
+---
+# GitHub Portfolio
+Summarize each repo: purpose, stack, impact.

--- a/data/linkedin.md
+++ b/data/linkedin.md
@@ -1,0 +1,6 @@
+---
+source: linkedin
+updated: 2025-10-03
+---
+# LinkedIn (Kamran Shirazi)
+Paste your About + Experience sections here.

--- a/data/resume.md
+++ b/data/resume.md
@@ -1,0 +1,6 @@
+---
+source: resume
+updated: 2025-10-03
+---
+# Resume (Kamran Shirazi)
+Paste your resume content here: roles, dates, metrics, tools.

--- a/docs/qas.yaml
+++ b/docs/qas.yaml
@@ -1,0 +1,11 @@
+- q: What’s your current degree program?
+  must_contain:
+    - "University of San Diego"
+    - "Applied Data Science"
+- q: Which BI tools have you used professionally?
+  must_contain:
+    - "Power BI"
+    - "Tableau"
+- q: Where did you optimize Redshift/Snowflake queries?
+  must_contain:
+    - "Lytx"

--- a/prompts/answer_policy.md
+++ b/prompts/answer_policy.md
@@ -1,0 +1,13 @@
+You are Kam-GPT, grounded only in the CONTEXT provided.
+
+Rules:
+- If the answer isn’t in CONTEXT, reply: “I don’t find that in my portfolio data.”
+- Always cite file names as evidence.
+- Prefer extractive quotes for dates, metrics, and titles.
+- Never guess; never use outside knowledge.
+- Suggest what should be added if missing.
+
+Answer format:
+1) Direct answer (1–3 sentences)
+2) Evidence (bulleted list of file names/snippets)
+3) Gaps (missing info)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 openai>=1.35.10
-streamlit>=1.31
+streamlit>=1.38.0
+faiss-cpu>=1.8.0
+numpy>=1.26.0

--- a/scripts/build_index.py
+++ b/scripts/build_index.py
@@ -1,0 +1,44 @@
+import os, glob, re, json
+from pathlib import Path
+import faiss, numpy as np
+
+def read_markdowns(folder="data"):
+    docs = []
+    for p in glob.glob(f"{folder}/*.md"):
+        txt = Path(p).read_text(encoding="utf-8", errors="ignore")
+        docs.append({"path": p, "text": txt})
+    return docs
+
+def chunk(text, path, size=800, overlap=120):
+    sents = re.split(r'(?<=[.!?])\s+', text.strip())
+    chunks, buf, length = [], [], 0
+    for s in sents:
+        buf.append(s); length += len(s)
+        if length >= size:
+            chunks.append({"path": path, "text": " ".join(buf)})
+            buf, length = [], 0
+    if buf:
+        chunks.append({"path": path, "text": " ".join(buf)})
+    return chunks
+
+def embed(texts):
+    dim = 4096
+    X = np.zeros((len(texts), dim), dtype="float32")
+    for i,t in enumerate(texts):
+        for tok in re.findall(r"[a-zA-Z0-9_]+", t.lower()):
+            X[i, hash(tok) % dim] += 1.0
+    X /= (np.linalg.norm(X, axis=1, keepdims=True)+1e-9)
+    return X, dim
+
+if __name__ == "__main__":
+    docs = []
+    for d in read_markdowns("data"):
+        docs += chunk(d["text"], d["path"])
+    texts = [d["text"] for d in docs]
+    X, dim = embed(texts)
+    idx = faiss.IndexFlatIP(dim)
+    idx.add(X)
+    os.makedirs("index", exist_ok=True)
+    faiss.write_index(idx, "index/faiss.index")
+    Path("index/meta.json").write_text(json.dumps(docs, indent=2))
+    print(f"Indexed {len(docs)} chunks.")


### PR DESCRIPTION
## Summary
- add FAISS-based index builder and lightweight hashing embeddings for markdown resume data
- expose retrieval helpers and Streamlit UI that surfaces grounded answers with evidence
- seed data, prompts, and QA templates to structure personal portfolio ingestion

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e017877da88323b822c93131c59d9f