### PR TITLE
Replace deprecated experimental rerun call

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -493,7 +493,7 @@ def render_sidebar() -> None:
 
         if st.button("Reset conversation"):
             st.session_state.pop("messages", None)
-            st.experimental_rerun()
+            st.rerun()
 
         st.subheader("Documents")
         _render_document_controls(


### PR DESCRIPTION
## Summary
- update the sidebar reset button to use `st.rerun()` instead of the deprecated `st.experimental_rerun()`

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e054bf7c9483238123852854a32665